### PR TITLE
Fix tools responsible for rebuilding local working site | #133315

### DIFF
--- a/utilities/container/reset
+++ b/utilities/container/reset
@@ -11,7 +11,7 @@ echo "Starting..."
 # Stop and remove the container and its image (if those things don't 
 # actually exist these commands will be noisey but harmless)
 docker stop mt-purple__helpdesk-utilities 2> /dev/null
-docker rm mt-purle__helpdesk-utilities 2> /dev/null
+docker rm mt-purple__helpdesk-utilities 2> /dev/null
 docker rmi mt-purple/helpdesk-utilities 2> /dev/null
 docker rmi mt-purple/helpdesk-utilities:latest 2> /dev/null
 

--- a/utilities/rebuild-local-copy
+++ b/utilities/rebuild-local-copy
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 
 # Directories
-SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+CURRENT_DIR="$( pwd )"
+CONTAINER_DIR="$( cd "$(dirname "$0")" ; pwd -P )/container"
 
-# Start the container and run the rebuild-local-copy script from within it,
-# then tidy things up again
-bash $SCRIPT_DIR/container/start
+# Jump to the container dir so the container start script has the correct context
+cd $CONTAINER_DIR
+
+# Run the rebuild command from within the container
+bash start
 docker exec mt-purple__helpdesk-utilities bash /scripts/rebuild-local-copy
-bash $SCRIPT_DIR/container/pause
+bash pause
+
+# Restore
+cd $CURRENT_DIR


### PR DESCRIPTION
* The container used to run the script which generates a local copy of LiveAgent was not always being created with the correct context.
* The command to reset the container was not functioning as expected due to a typo.

:ticket: [♯133315](https://central.tri.be/issues/133315)